### PR TITLE
Changes to how queues are started and tasks are created. Some tests were written, and Logger was added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ defmodule ExampleWorker do
         a+b
     end
 end
-Zucchini.start_queue(%{name: queue_name})
-Zucchini.async(&ExampleWorker.add_two_numers/2, queue_name)
+
+Zucchini.start(:queue_name)
+Zucchini.create_job(ExampleWorker, :add_two_numbers, [2, 3])
+|> Zucchini.async(:queue_name)
 ```

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,3 @@
+import Config
+
+import_config "./#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+import Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,2 @@
+import Config
+config :logger, level: :critical

--- a/lib/zucchini.ex
+++ b/lib/zucchini.ex
@@ -1,9 +1,22 @@
 defmodule Zucchini do
   alias Zucchini.{Job, Registry, Queue, Queues}
+  require Logger
 
-  @type queue_name :: String.t | atom | {:global, String.t | atom}
+  @type queue_name :: atom()
   @type task :: {atom, [arg :: term]}
   @type async_opt :: {:reply, true} | {:delay_secs, pos_integer()}
+
+  @spec start(queue_name, []) :: {:ok, pid} | {:error, term()}
+  def start(queue_name, opts \\ []) do
+    with {:ok, pid} <- Queues.start_queue(%{name: queue_name})
+      do
+        Logger.info("Started Queue #{inspect queue_name} at #{inspect(pid)}")
+        {:ok, pid}
+      else
+        {:error, reason} ->
+          Logger.error("Failed to start queue with name #{queue_name}. Reason: #{inspect reason}")
+      end
+  end
 
   @spec async(task, queue_name, [async_opt]) :: Job.t | no_return
   def async(task, queue, opts \\ []) do
@@ -27,9 +40,8 @@ defmodule Zucchini do
 
 
   @doc false
-  def no_queue_error(%Job{queue: {:queue, _} = queue} = job) do
+  def no_queue_error(%Job{queue: _queue_name = queue} = job) do
     "`unable to to find queue: #{inspect queue}, cannot enqueue job #{inspect job}"
   end
 
-  defdelegate start_queue(args), to: Queues
 end

--- a/lib/zucchini.ex
+++ b/lib/zucchini.ex
@@ -13,7 +13,6 @@ defmodule Zucchini do
   Starts a queue with the given name and opts.
 
   ## Parameters
-
       - queue_name: an atom representing the name of the queue to be created
       - opts: a map containing key-value pairs related to the queue and workers started
 
@@ -56,6 +55,7 @@ defmodule Zucchini do
     |> Registry.exists?
     |> case do
       true -> queue
+      # change to logger
       false -> raise RuntimeError, no_queue_error(job)
     end
     |> Queue.enqueue(job)

--- a/lib/zucchini.ex
+++ b/lib/zucchini.ex
@@ -1,17 +1,24 @@
 defmodule Zucchini do
+
   alias Zucchini.{Job, Registry, Queue, Queues}
   require Logger
 
   @type queue_name :: atom()
   @type task :: {atom, [arg :: term]}
   @type async_opt :: {:reply, true} | {:delay_secs, pos_integer()}
+  @type queue_opts :: map()
+  @doc """
+  Starts a queue with the given name and workers.
 
-  @spec start(queue_name, []) :: {:ok, pid} | {:error, term()}
-  def start(queue_name, opts \\ []) do
-    with {:ok, pid} <- Queues.start_queue(%{name: queue_name})
+  opts is of type map and can take the following keys:
+    * `num` — number of workers to spawn with queue
+  """
+  @spec start(queue_name, queue_opts()) :: {:ok, pid} | {:error, term()}
+  def start(queue_name, opts \\ %{}) do
+    queue_opts = Map.put_new(opts, :name, queue_name)
+    with {:ok, pid} <- Queues.start_queue(queue_opts)
       do
         Logger.info("Started Queue #{inspect queue_name} at #{inspect(pid)}")
-        {:ok, pid}
       else
         {:error, reason} ->
           Logger.error("Failed to start queue with name #{queue_name}. Reason: #{inspect reason}")

--- a/lib/zucchini.ex
+++ b/lib/zucchini.ex
@@ -4,7 +4,7 @@ defmodule Zucchini do
   require Logger
 
   @type queue_name :: atom()
-  @type task :: {atom, [arg :: term]}
+  @type job :: %Job{}
   @type async_opt :: {:reply, true} | {:delay_secs, pos_integer()}
   @type queue_opts :: map()
   @doc """
@@ -25,13 +25,17 @@ defmodule Zucchini do
       end
   end
 
-  @spec async(task, queue_name, [async_opt]) :: Job.t | no_return
-  def async(task, queue, opts \\ []) do
+  @spec async(job(), queue_name, [async_opt]) :: Job.t | no_return
+  def async(job, queue, opts \\ []) do
     queue_pid = Zucchini.Registry.whereis_name({:queue, queue})
-    job = Job.new(task, queue, queue_pid, self())
+    Job.new(job, opts, queue, queue_pid, self())
     |> enqueue
   end
 
+
+  def create_job(module, function, args) do
+    Job.new(module, function, args)
+  end
 
 
   def enqueue(%Job{queue: queue} = job) do

--- a/lib/zucchini/example_worker.ex
+++ b/lib/zucchini/example_worker.ex
@@ -1,5 +1,5 @@
 defmodule Zucchini.ExampleWorker do
-    
+
     def add(a, b) do
         {:ok, a+b}
     end
@@ -10,7 +10,7 @@ defmodule Zucchini.ExampleWorker do
     end
 
     def sleep_task(milliseconds) do
-         Process.sleep(30000)
+         Process.sleep(milliseconds)
          IO.puts("finished sleeping...")
     end
 end

--- a/lib/zucchini/example_worker.ex
+++ b/lib/zucchini/example_worker.ex
@@ -4,6 +4,10 @@ defmodule Zucchini.ExampleWorker do
         {:ok, a+b}
     end
 
+    def add(a, b, c) do
+        {:ok, a+b+c}
+    end
+
     def reverse(list) do
         res = Enum.reverse(list)
         {:ok, res}

--- a/lib/zucchini/job.ex
+++ b/lib/zucchini/job.ex
@@ -20,11 +20,11 @@ defmodule Zucchini.Job do
                 :completed_at]
 
 
-    def new(job = %__MODULE__{}, opts, queue, queue_pid, from) do
+    def new(job = %__MODULE__{}, _opts, queue, queue_pid, from) do
         %__MODULE__{ job | queue: queue, queue_pid: queue_pid, enqueued_at: System.system_time(:millisecond), from: from}
     end
 
-    def new(module, function, args) do
+    defp new(module, function, args) do
         %__MODULE__{task: {module, function, args}}
     end
 
@@ -45,9 +45,10 @@ defmodule Zucchini.Job do
     def create_job(module, function, args) when is_list(args) do
         case verify_task(module, function, length(args)) do
             true ->
-                __MODULE__.new(module, function, args)
+                new(module, function, args)
             false ->
                 Logger.error("Failed to create job: #{inspect module} #{inspect function} with arity #{inspect length(args)} either does not exist or is not public")
+                :error
         end
     end
 

--- a/lib/zucchini/job.ex
+++ b/lib/zucchini/job.ex
@@ -1,14 +1,14 @@
 defmodule Zucchini.Job do
-    
+
     # :task - task to be done
     # :queue - queue job belongs to
-    # :enqueued_at - time job was enqueued at 
+    # :enqueued_at - time job was enqueued at
     # :from - process that requested the job, incase a reply is needed
     # :result - the result of running the task
     # :job_monitor - monitor for the job incase it fails
     # :start_at - the time the job began being ran
     # :completed_at - the time the job finished
-    defstruct [ :task, 
+    defstruct [ :task,
                 :queue,
                 :queue_pid,
                 :enqueued_at,
@@ -19,12 +19,16 @@ defmodule Zucchini.Job do
                 :started_at,
                 :completed_at]
 
-    @type t :: %__MODULE__{
-        task: Zucchini.task | nil,
-        queue: Zucchini.queue_name
-    }
 
-    def new(task, queue, queue_pid, from) do
-        %__MODULE__{task: task, queue: queue, queue_pid: queue_pid, enqueued_at: System.system_time(:millisecond), from: from}
+    def new(job = %__MODULE__{}, opts, queue, queue_pid, from) do
+        %__MODULE__{ job | queue: queue, queue_pid: queue_pid, enqueued_at: System.system_time(:millisecond), from: from}
+    end
+
+    def new(module, function, args) do
+        %__MODULE__{task: {module, function, args}}
+    end
+
+    def verify_task() do
+
     end
 end

--- a/lib/zucchini/job.ex
+++ b/lib/zucchini/job.ex
@@ -1,5 +1,5 @@
 defmodule Zucchini.Job do
-
+    require Logger
     # :task - task to be done
     # :queue - queue job belongs to
     # :enqueued_at - time job was enqueued at
@@ -28,7 +28,38 @@ defmodule Zucchini.Job do
         %__MODULE__{task: {module, function, args}}
     end
 
-    def verify_task() do
+    @doc """
+    Creates a Job struct containing the appropriate task keyword for the passed in module, function, args
+
+    create_job/2 takes in a function and args,
+
+    ## Parameters
+
+  """
+
+    def create_job(function, args) when is_list(args) do
+        [module: module, name: name, arity: _arity, env: _, type: _] = Function.info function
+        create_job(module, name, args)
+    end
+
+    def create_job(module, function, args) when is_list(args) do
+        case verify_task(module, function, length(args)) do
+            true ->
+                __MODULE__.new(module, function, args)
+            false ->
+                Logger.error("Failed to create job: #{inspect module} #{inspect function} with arity #{inspect length(args)} either does not exist or is not public")
+        end
+    end
+
+    def verify_task(module, function, arity) do
+       Keyword.get_values(module.__info__(:functions), function)
+       |> Enum.member?(arity)
+       |> case do
+        true ->
+            true
+        false ->
+            false
+       end
 
     end
 end

--- a/lib/zucchini/job_runner.ex
+++ b/lib/zucchini/job_runner.ex
@@ -45,11 +45,11 @@ defmodule Zucchini.JobRunner do
     end
 
     @impl true
-  def terminate(:normal, _state), do: :ok
-  def terminate(:shutdown, _state), do: :ok
-  def terminate({:shutdown, _}, _state), do: :ok
-  def terminate(reason, _state) do
-    Logger.info("[Zucchini] JobRunner #{inspect self()} stopped because #{inspect reason}")
-  end
+    def terminate(:normal, _state), do: :ok
+    def terminate(:shutdown, _state), do: :ok
+    def terminate({:shutdown, _}, _state), do: :ok
+    def terminate(reason, _state) do
+        Logger.info("[Zucchini] JobRunner #{inspect self()} stopped because #{inspect reason}")
+    end
 
 end

--- a/lib/zucchini/job_runner.ex
+++ b/lib/zucchini/job_runner.ex
@@ -2,6 +2,7 @@ defmodule Zucchini.JobRunner do
     use GenServer
 
     alias Zucchini.{Job, Worker}
+    require Logger
 
     defmodule State do
         defstruct [:worker, :job, :module]
@@ -12,7 +13,7 @@ defmodule Zucchini.JobRunner do
         GenServer.start_link(__MODULE__, opts)
     end
 
-       
+
     # end
     @impl true
     def init(%Job{} = opts) do
@@ -21,15 +22,14 @@ defmodule Zucchini.JobRunner do
         }, {:continue, :run}}
     end
 
-    defp run_job(%State{job: %Job{task: task, worker: worker_pid} = job,
-                module: module} = state) do
+    defp run_job(%State{job: %Job{task: task, worker: worker_pid} = job} = state) do
         #run job
-        result = 
+        result =
             case task do
-                f when is_function(f) -> apply(f, [5000])
-            end    
+                {module, f, args} -> apply(module, f, args)
+            end
         job = %{job | result: result}
-        
+
         Task.async( fn ->  Worker.job_complete(worker_pid, job) end)
 
         job
@@ -37,9 +37,10 @@ defmodule Zucchini.JobRunner do
     end
 
 
+    @impl true
     def handle_continue(:run, state) do
        state = run_job(state)
-        
+
         {:stop, :normal, state}
     end
 
@@ -48,7 +49,7 @@ defmodule Zucchini.JobRunner do
   def terminate(:shutdown, _state), do: :ok
   def terminate({:shutdown, _}, _state), do: :ok
   def terminate(reason, _state) do
-    IO.puts "[Zucchini] JobRunner #{inspect self()} stopped because #{inspect reason}"
+    Logger.info("[Zucchini] JobRunner #{inspect self()} stopped because #{inspect reason}")
   end
 
 end

--- a/lib/zucchini/queue.ex
+++ b/lib/zucchini/queue.ex
@@ -10,7 +10,7 @@ defmodule Zucchini.Queue do
             :queue_name,
             :module,
             :worker_cache
-        ] 
+        ]
     end
 
     def start_link(%{name: queue_name} = opts) do
@@ -20,7 +20,7 @@ defmodule Zucchini.Queue do
     @impl true
     def init(%{name: queue_name} = arg) do
         {:ok, worker_cache_pid} = WorkerCache.start_link(%{name: queue_name})
-        Workers.start_workers(queue_name, worker_cache_pid, Zucchini.ExampleWorker, %{})
+        Workers.start_workers(queue_name, worker_cache_pid, Zucchini.ExampleWorker, arg)
         {:ok, %State{queue: :queue.new, queue_name: queue_name, worker_cache: worker_cache_pid}}
     end
 
@@ -36,7 +36,7 @@ defmodule Zucchini.Queue do
       state = %{state | queue: :queue.in(job, queue)}
       {job, state}
     end
-    
+
     defp via_tuple(queue_name) do
         {:via, Zucchini.Registry, {:queue, queue_name}}
     end
@@ -58,10 +58,10 @@ defmodule Zucchini.Queue do
                 _ ->
                     {job, state} = do_enqueue(job, state)
             end
-  
+
         {:reply, {:ok, job}, state}
     end
-   
+
 
     @impl true
     def handle_cast({:dequeue}, %State{worker_cache: cache_pid} = state) do

--- a/lib/zucchini/queues.ex
+++ b/lib/zucchini/queues.ex
@@ -13,15 +13,18 @@ defmodule Zucchini.Queues do
 
 
     def start_queue(args) do
-        with {:ok, child} <- Supervisor.start_child(__MODULE__, Queue.do_child_spec(args)) do
-            {:ok, child}
-        end
+        with {:ok, child} <- Supervisor.start_child(__MODULE__, Queue.do_child_spec(args))
+            do
+                {:ok, child}
+            else
+                {:error, reason} -> {:error, "Failed to start Queue for reason: #{inspect reason}"}
+            end
     end
 
     def start_link(args) do
         Supervisor.start_link(__MODULE__, args, name: __MODULE__)
     end
-    
+
     @impl true
     def init(_args) do
         Supervisor.init([], strategy: :one_for_one)

--- a/lib/zucchini/worker.ex
+++ b/lib/zucchini/worker.ex
@@ -5,7 +5,7 @@ defmodule Zucchini.Worker do
     alias Zucchini.JobRunner
     alias Zucchini.WorkerCache
     @type private :: term
-    
+
     @callback init(args :: term) :: {:ok, state :: private}
 
     # :queue - name of queue worker belongs to
@@ -18,7 +18,7 @@ defmodule Zucchini.Worker do
             :queue_pid,
             :worker_cache,
             {:ready, false}
-        ] 
+        ]
     end
     def start_link(opts) do
         worker = GenServer.start_link(__MODULE__, opts)
@@ -49,7 +49,8 @@ defmodule Zucchini.Worker do
     def handle_call({:run, job}, _from, state) do
         {:reply, do_run(job, state), state}
     end
-   
+
+    @impl true
     def handle_cast({:job_complete, %Job{from: from, worker: worker}= job}, %{worker_cache: worker_cache} = state) do
         send(from, job)
         WorkerCache.checkin(worker_cache, worker)

--- a/lib/zucchini/worker_supervisor.ex
+++ b/lib/zucchini/worker_supervisor.ex
@@ -2,18 +2,20 @@ defmodule Zucchini.WorkerSupervisor do
 
     alias Zucchini.Worker
     alias Zucchini.WorkerCache
+    require Logger
     use DynamicSupervisor
-    
+
     def start_link(%{name: name, num: num, worker_cache: worker_cache} = init_arg) do
         {:ok, supervisor} = DynamicSupervisor.start_link(__MODULE__, init_arg, name: name)
-        Enum.each(1..num, fn _ ->
+        Enum.each(1..num, fn number ->
           {:ok, pid} = start_worker([supervisor] ++ [init_arg])
+          Logger.info("Started worker ##{number} with pid #{inspect pid}")
           WorkerCache.checkin(worker_cache, pid)
         end
         )
         {:ok, supervisor}
     end
-    
+
       @impl true
       def init(init_arg) do
         DynamicSupervisor.init(strategy: :one_for_one)

--- a/lib/zucchini/worker_supervisor.ex
+++ b/lib/zucchini/worker_supervisor.ex
@@ -1,5 +1,4 @@
 defmodule Zucchini.WorkerSupervisor do
-
     alias Zucchini.Worker
     alias Zucchini.WorkerCache
     require Logger

--- a/lib/zucchini/workers.ex
+++ b/lib/zucchini/workers.ex
@@ -13,18 +13,9 @@ defmodule Zucchini.Workers do
     end
 
 
-    def start_workers(name, worker_cache, module_and_args, worker_opts) do
-        {module, args} =
-            case module_and_args do
-                module when is_atom(module) -> {module, []}
-                {module, args} -> {module, args}
-            end
-
-
-
+    def start_workers(name, worker_cache, worker_opts) do
         opts = %{
             name: name,
-            ma: {module, args},
             num: worker_opts[:num] || 10,
             worker_cache: worker_cache
         }

--- a/lib/zucchini/workers.ex
+++ b/lib/zucchini/workers.ex
@@ -6,7 +6,7 @@ defmodule Zucchini.Workers do
     def start_link(args) do
         Supervisor.start_link(__MODULE__, args, name: __MODULE__)
     end
-    
+
     @impl true
     def init(_args) do
         Supervisor.init([], strategy: :one_for_one)
@@ -19,7 +19,7 @@ defmodule Zucchini.Workers do
                 module when is_atom(module) -> {module, []}
                 {module, args} -> {module, args}
             end
-        
+
 
 
         opts = %{
@@ -29,7 +29,7 @@ defmodule Zucchini.Workers do
             worker_cache: worker_cache
         }
 
-        child_spec = 
+        child_spec =
             WorkerSupervisor.child_spec(opts)
             |> Map.put(:id, name)
 
@@ -37,7 +37,7 @@ defmodule Zucchini.Workers do
             {:ok, child}
         end
 
-    
+
     end
-    
+
 end

--- a/test/zucchini_test.exs
+++ b/test/zucchini_test.exs
@@ -1,12 +1,81 @@
 defmodule ZucchiniTest do
   use ExUnit.Case
-  alias Zucchini.{Job,Queue}
 
   doctest Zucchini
 
-  test "initialize queue and enqueue something" do
-    Zucchini.Queues.start_queue(%{name: "testqueue"})
-    
-    assert :ok == :ok
+  describe "Zucchini module functions:" do
+
+    setup do
+      Zucchini.start(:testQueue)
+      [job: Zucchini.Job.create_job(Zucchini.ExampleWorker, :add, [2, 3])]
+    end
+
+    test "start/1 returns :ok on success" do
+      assert :ok == Zucchini.start(:queue)
+    end
+
+    test "start/1 returns :error on failure" do
+      assert :error == Zucchini.start(:testQueue)
+    end
+
+    test "start/2 starts the correct number of workers" do
+      # UNIMPLEMENTED
+      assert :ok == :ok
+    end
+
+    test "async/2 returns " do
+      # UNIMPLEMENTED
+      assert :ok == :ok
+    end
   end
+
+  describe "Job module functions:" do
+
+    test "verify_task/3 returns true when function and arity exists" do
+      assert true == Zucchini.Job.verify_task(__MODULE__, :test_function, 3)
+      assert true == Zucchini.Job.verify_task(__MODULE__, :test_function, 2)
+    end
+
+    test "verify_task/3 returns false when function and arity exists" do
+      assert false == Zucchini.Job.verify_task(__MODULE__, :test_function, 0)
+      assert false == Zucchini.Job.verify_task(__MODULE__, :test_function, 0)
+      assert false == Zucchini.Job.verify_task(__MODULE__, :noexistent_function, 3)
+    end
+
+    test "create_job/2 returns a job struct containing the correct task when existing function is passed in" do
+      %Zucchini.Job{task: task} = Zucchini.Job.create_job(&__MODULE__.test_function/3, [0, 0, 0])
+      %Zucchini.Job{task: task_with_2_args} = Zucchini.Job.create_job(&__MODULE__.test_function/3, [0, 0])
+      assert {ZucchiniTest, :test_function, [0, 0, 0]} == task
+      assert {ZucchiniTest, :test_function, [0, 0]} == task_with_2_args
+    end
+
+    test "create_job/2 returns an error atom on non existent function" do
+      assert :error == Zucchini.Job.create_job(&__MODULE__.noexistent_function/3, [0, 0, 0])
+    end
+
+    test "create_job/2 returns an error atom on existing function but incorrect arity" do
+      assert :error == Zucchini.Job.create_job(&__MODULE__.test_function/3, [0])
+    end
+
+    test "create_job/3 returns a job struct containing the correct task when existing function is passed in" do
+      %Zucchini.Job{task: task} = Zucchini.Job.create_job(__MODULE__, :test_function, [0, 0, 0])
+      %Zucchini.Job{task: task_with_2_args} = Zucchini.Job.create_job(__MODULE__, :test_function, [0, 0])
+      assert {ZucchiniTest, :test_function, [0, 0, 0]} == task
+      assert {ZucchiniTest, :test_function, [0, 0]} == task_with_2_args
+    end
+
+    test "create_job/3 returns an error atom on existing function but incorrect arity" do
+      assert :error == Zucchini.Job.create_job(__MODULE__, :test_function, [0])
+    end
+
+    test "create_job/3 returns an error atom on non existent function" do
+      assert :error == Zucchini.Job.create_job(__MODULE__, :noexistent_function, [0, 0, 0])
+    end
+
+  end
+
+  def test_function(a, b, c \\ 2) do
+    [a, b, c]
+  end
+
 end


### PR DESCRIPTION
## **Changes**
 - *Added config*
 - *Added Logger outputs to some functions (still missing others)*
 - *Added new functions*
	 - **Zucchini.start/2**
	 - **Job.create_job/2**
	 - **Job.create_job/3**
	 - **Job.veriy_task/3**
 -  *Added inline documentation for:*
	 - **Zucchini.start/2**
	 - **Zucchini.async/3**
	 - **Job.create_job/3**
 - *Made changes to how a queue and its respective workers are started* 
	 ```elixir
	Zucchini.start(:queue_name)
	```
- *Made changes to how a job is created (allowing for any module to be passed in), making it simpler and more streamlined*
	``` elixir
	job = Zucchini.create_job(MODULE, :function, [function_args])
	
    #job can then be passed into async/2
	#job |> Zucchini.async(:queue_name)
	```
- *Finally, added tests for some functions in the Zucchini module and Job module*